### PR TITLE
Added method to add thread-id to aps, see https://developer.apple.com…

### DIFF
--- a/src/main/java/com/clevertap/apns/Notification.java
+++ b/src/main/java/com/clevertap/apns/Notification.java
@@ -223,6 +223,11 @@ public class Notification {
             return this;
         }
 
+        public Builder threadId(String threadId) {
+            aps.put("thread-id", threadId);
+            return this;
+        }
+
         public Builder customField(String key, Object value) {
             root.put(key, value);
             return this;


### PR DESCRIPTION
…/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html, in order to support the new iOS 12 feature to group notifications on the iOS device